### PR TITLE
Lib Elf Adress - Match the ELF Adress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ CC 		= 	gcc
 MAIN	=	src/main.c
 
 FILES	=	src/ftrace_start.c 				\
-			src/ftrace_error_handling.c
+			src/ftrace_error_handling.c		\
+			src/utils.c
 
-ELFLIB	=	src/elf_lib/elf_open.c
+ELFLIB	=	src/elf_lib/elf_open.c		\
+			src/elf_lib/elf_adress.c
 
 SRC 	=	$(MAIN)		\
 			$(FILES)	\

--- a/include/elf_adress.h
+++ b/include/elf_adress.h
@@ -1,0 +1,30 @@
+/*
+** EPITECH PROJECT, 2022
+** Project
+** File description:
+** elf_adress
+*/
+
+#ifndef ELF_ADRESS_H_
+    #define ELF_ADRESS_H_
+
+    #include "elf_open.h"
+    #include <stdlib.h>
+
+    #define ELF_ADRESS_ERROR NULL
+    #define ELF_ADRESS_SUCCESS 0
+    #define ELF_ADRESS_FAIL 1
+
+typedef struct elf_adress_s {
+    GElf_Shdr symtab;
+    GElf_Shdr strtab;
+    Elf64_Sym *sym;
+    char *str;
+} elf_adress_t;
+
+elf_adress_t *init_elf_adress(elf_info_t *elf_info);
+int fill_elf_adress(elf_info_t *elf_info, elf_adress_t *elf_adress,
+size_t shstrndx);
+char *elf_get_name_from_adress(elf_info_t *elf_info, char *adress);
+
+#endif /* !ELF_ADRESS_H_ */

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,13 @@
+/*
+** EPITECH PROJECT, 2022
+** Project
+** File description:
+** utils
+*/
+
+#ifndef UTILS_H_
+    #define UTILS_H_
+
+int hex_to_dec(char *adress);
+
+#endif /* !UTILS_H_ */

--- a/src/elf_lib/elf_adress.c
+++ b/src/elf_lib/elf_adress.c
@@ -18,6 +18,12 @@
 #include <string.h>
 #include <stdio.h>
 
+/**
+*@brief init the elf_adress structure
+*
+*@param elf_info
+*@return elf_adress_t*
+*/
 elf_adress_t *init_elf_adress(elf_info_t *elf_info)
 {
     elf_adress_t *elf_adress = malloc(sizeof(elf_adress_t) * 1);
@@ -36,6 +42,14 @@ elf_adress_t *init_elf_adress(elf_info_t *elf_info)
     return elf_adress;
 }
 
+/**
+*@brief fill the elf adress structure (match the str and sym tab)
+*
+*@param elf_info
+*@param elf_adress
+*@param shstrndx
+*@return int
+*/
 int fill_elf_adress(elf_info_t *elf_info, elf_adress_t *elf_adress,
 size_t shstrndx)
 {
@@ -61,6 +75,13 @@ size_t shstrndx)
     return ELF_ADRESS_SUCCESS;
 }
 
+/**
+*@brief return the matching name for the given adress in an ELF file
+*
+*@param elf_info
+*@param adress
+*@return char*
+*/
 char *elf_get_name_from_adress(elf_info_t *elf_info, char *adress)
 {
     elf_adress_t *elf_adress = init_elf_adress(elf_info);

--- a/src/elf_lib/elf_adress.c
+++ b/src/elf_lib/elf_adress.c
@@ -1,0 +1,86 @@
+/*
+** EPITECH PROJECT, 2022
+** Project
+** File description:
+** elf_adress
+*/
+
+#include "elf_open.h"
+#include "elf_adress.h"
+#include "utils.h"
+#include <stddef.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sysexits.h>
+#include <string.h>
+#include <stdio.h>
+
+elf_adress_t *init_elf_adress(elf_info_t *elf_info)
+{
+    elf_adress_t *elf_adress = malloc(sizeof(elf_adress_t) * 1);
+    size_t shstrndx = 0;
+
+    if (elf_adress == NULL)
+        return ELF_ADRESS_ERROR;
+    if (elf_getshdrstrndx(elf_info->elf_file, &shstrndx) != 0) {
+        errx(EX_SOFTWARE, "elf_getshdrstrndx() failed : %s.", elf_errmsg(-1));
+        return ELF_ADRESS_ERROR;
+    }
+    if (fill_elf_adress(elf_info, elf_adress, shstrndx)) {
+        free(elf_adress);
+        return ELF_ADRESS_ERROR;
+    }
+    return elf_adress;
+}
+
+int fill_elf_adress(elf_info_t *elf_info, elf_adress_t *elf_adress,
+size_t shstrndx)
+{
+    Elf_Scn *scn = NULL;
+    GElf_Shdr shdr;
+    char *name = NULL;
+
+    while ((scn = elf_nextscn(elf_info->elf_file, scn)) != NULL) {
+        if (gelf_getshdr(scn, &shdr) != &shdr) {
+            errx(EX_SOFTWARE, "getshdr() failed: %s.", elf_errmsg(-1));
+            return ELF_ADRESS_FAIL;
+        }
+        if ((name = elf_strptr(elf_info->elf_file,
+        shstrndx, shdr.sh_name)) == NULL) {
+            errx(EX_SOFTWARE, "elf_strptr() failed: %s.", elf_errmsg(-1));
+            return ELF_ADRESS_FAIL;
+        }
+        if (strcmp(name, ".symtab") == 0)
+            elf_adress->symtab = shdr;
+        if (strcmp(name, ".strtab") == 0)
+            elf_adress->strtab = shdr;
+    }
+    return ELF_ADRESS_SUCCESS;
+}
+
+char *elf_get_name_from_adress(elf_info_t *elf_info, char *adress)
+{
+    elf_adress_t *elf_adress = init_elf_adress(elf_info);
+    char *name = NULL;
+
+    if (elf_adress == ELF_ADRESS_ERROR)
+        return ELF_ADRESS_ERROR;
+    if (!elf_adress->symtab.sh_size || !elf_adress->strtab.sh_size)
+        return ELF_ADRESS_ERROR;
+    elf_adress->sym = (Elf64_Sym *) (elf_info->buf +
+    elf_adress->symtab.sh_offset);
+    elf_adress->str = (char *) (elf_info->buf + elf_adress->strtab.sh_offset);
+    for (size_t i = 1; i < elf_adress->symtab.sh_size /
+    elf_adress->symtab.sh_entsize; i++) {
+        if (elf_adress->sym[i].st_info != STT_SECTION &&
+            elf_adress->sym[i].st_info != STT_FILE && hex_to_dec(adress) ==
+            elf_adress->sym[i].st_value &&
+            ((char *)(elf_adress->str + elf_adress->sym[i].st_name))[0] != '.')
+            name = elf_adress->str + elf_adress->sym[i].st_name;
+    }
+    free(elf_adress);
+    return name;
+}

--- a/src/elf_lib/elf_open.c
+++ b/src/elf_lib/elf_open.c
@@ -27,8 +27,10 @@ elf_info_t *elf_info_init(char *path)
     if (elf_info == NULL)
         return NULL;
     elf_info->fd = open(path, O_RDONLY);
-    if (elf_info->fd == OPEN_ERROR)
+    if (elf_info->fd == OPEN_ERROR) {
+        free(elf_info);
         return NULL;
+    }
     fstat(elf_info->fd, &(elf_info->size));
     elf_info->buf = mmap(NULL, elf_info->size.st_size, PROT_READ,
     MAP_PRIVATE, elf_info->fd, 0);

--- a/src/ftrace_start.c
+++ b/src/ftrace_start.c
@@ -8,6 +8,7 @@
 #include "ftrace_start.h"
 #include "ftrace_error_handling.h"
 #include "elf_open.h"
+#include "elf_adress.h"
 #include <stddef.h>
 
 /**
@@ -32,6 +33,7 @@ int ftrace_start(int ac, char **av)
     elf_info = elf_info_init(av[1]);
     if (elf_info == NULL)
         return 84;
+    printf("Adress name is : %s\n", elf_get_name_from_adress(elf_info, "401126"));
     elf_info_destroy(elf_info);
     return 0;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,6 +8,12 @@
 #include "utils.h"
 #include <stdlib.h>
 
+/**
+*@brief convert hex number to decimal
+*
+*@param adress
+*@return int
+*/
 int hex_to_dec(char *adress)
 {
     return ((int)strtol(adress, NULL, 16));

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,14 @@
+/*
+** EPITECH PROJECT, 2022
+** Project
+** File description:
+** utils
+*/
+
+#include "utils.h"
+#include <stdlib.h>
+
+int hex_to_dec(char *adress)
+{
+    return ((int)strtol(adress, NULL, 16));
+}


### PR DESCRIPTION
ELF Adress :

Parse an ELF File to find strtab and symtab.

Run across the symtab to find the matching function to adress.